### PR TITLE
Ensure users have write permissions on package directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ apt-get install --yes \
   "ca-certificates=20240203" \
   "curl=8.5.0-2ubuntu10.6" \
   "git=1:2.43.0-1ubuntu7.2" \
-  "gpg=2.4.4-2ubuntu17" \
+  "gpg=2.4.4-2ubuntu17.2" \
   "jq=1.7.1-3build1" \
   "unzip=6.0-28ubuntu4.1"
 
@@ -136,6 +136,8 @@ apt-get clean --yes
 
 rm --force --recursive /var/lib/apt/lists/* 3bf863cc.pub nvidia.gpg
 EOF
+
+RUN chmod -R 777 /usr/local/lib/R/site-library
 
 USER ${CONTAINER_UID}
 WORKDIR ${ANALYTICAL_PLATFORM_DIRECTORY}


### PR DESCRIPTION
This is an issue for R users, as currently running:

```
RUN R -e "install.packages('renv')"
RUN R -e 'renv::init()'
RUN R -e 'renv::restore()'
```

The standard process for setting up an R project, will error out due to not having permissions to write to package dir. Temp solution is for users to change to root, modify ownership, and change back, but easier to just do it for them in the build.

Also, updates GPG to allow successful image build.