### PR TITLE
📌 Patching 4/6/25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:a658d4be9ef8f95742fa7ff630226d0754ece827c6de984b7ac406866f56d653
+FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:932333528e27f2be8ae92535c4c3c2c1030a4cf368abbec1cf61d9ee8aa7cf41
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
@@ -18,7 +18,7 @@ ENV CONTAINER_USER="analyticalplatform" \
     AIRFLOW_RUNTIME_VERSION="${AIRFLOW_RUNTIME_VERSION}" \
     ANALYTICAL_PLATFORM_DIRECTORY="/opt/analyticalplatform" \
     DEBIAN_FRONTEND="noninteractive" \
-    AWS_CLI_VERSION="2.27.17" \
+    AWS_CLI_VERSION="2.27.28" \
     CUDA_VERSION="12.9.0" \
     R_VERSION="4.5.0-3.2404.0" \
     NVIDIA_DISABLE_REQUIRE="true" \
@@ -52,7 +52,7 @@ RUN <<EOF
 apt-get update --yes
 
 apt-get install --yes \
-  "apt-transport-https=2.7.14build2" \
+  "apt-transport-https=2.8.3" \
   "ca-certificates=20240203" \
   "curl=8.5.0-2ubuntu10.6" \
   "git=1:2.43.0-1ubuntu7.2" \

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -32,7 +32,7 @@ commandTests:
   - name: "aws"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli/2.27.17"]
+    expectedOutput: ["aws-cli/2.27.28"]
 
   - name: "r"
     command: "R"


### PR DESCRIPTION
This PR patches...

- AWS CLI upgraded from `2.27.17` to `2.27.28`
- Base image updated sha
- Updated `apt-transport-https` from `2.7.14build2` to `2.8.3`