### PR TITLE
updated base image

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -17,6 +17,6 @@ jobs:
       contents: write
       id-token: write
       packages: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml@f3b2ed398ec5c17e2f59d983bc01c79c73632246 # v7.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-release.yml@497b26456c1f0cff118cf5f663b66794d368f3e8 # v8.0.2
     secrets:
       release-failure-webhook-url: ${{ secrets.ANALYTICAL_PLATFORM_RELEASE_FAILURE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/container-test.yml
+++ b/.github/workflows/container-test.yml
@@ -13,4 +13,4 @@ jobs:
     name: Container Test
     permissions:
       contents: read
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-test.yml@f3b2ed398ec5c17e2f59d983bc01c79c73632246 # v7.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-test.yml@497b26456c1f0cff118cf5f663b66794d368f3e8 # v8.0.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-dependency-review.yml@f3b2ed398ec5c17e2f59d983bc01c79c73632246 # v7.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-dependency-review.yml@497b26456c1f0cff118cf5f663b66794d368f3e8 # v8.0.2

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,4 +16,4 @@ jobs:
       packages: read
       pull-requests: write
       statuses: write
-    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@f3b2ed398ec5c17e2f59d983bc01c79c73632246 # v7.3.0
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@497b26456c1f0cff118cf5f663b66794d368f3e8 # v8.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV CONTAINER_USER="analyticalplatform" \
     AIRFLOW_RUNTIME_VERSION="${AIRFLOW_RUNTIME_VERSION}" \
     ANALYTICAL_PLATFORM_DIRECTORY="/opt/analyticalplatform" \
     DEBIAN_FRONTEND="noninteractive" \
-    AWS_CLI_VERSION="2.34.39" \
+    AWS_CLI_VERSION="2.35.17" \
     CUDA_VERSION="13.1.0" \
     NVIDIA_DISABLE_REQUIRE="true" \
     NVIDIA_CUDA_COMPAT_VERSION="590.48.01-0ubuntu1" \
@@ -53,6 +53,7 @@ apt-get update --yes
 
 apt-get install --yes \
   "apt-transport-https=2.8.3" \
+  "gzip=1.12-1ubuntu3.2" \
   "ca-certificates=20260601~24.04.1" \
   "curl=8.5.0-2ubuntu10.10" \
   "git=1:2.43.0-1ubuntu7.3" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:748740465d0aadaa69ab6e6c295892f17d7a8f44a85090dbb571ec0bb8c5674f
+FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:22a8228e1e48cbe7e0e0f2056e752ffb8a35950cda150a4e5e16417200bec648
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -32,7 +32,7 @@ commandTests:
   - name: "aws"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli/2.34.39"]
+    expectedOutput: ["aws-cli/2.35.17"]
 
   - name: "r"
     command: "R"


### PR DESCRIPTION
This pull request updates the base image used in the `Dockerfile` to a newer version. This change ensures that the image uses the latest security patches and improvements from the upstream Ubuntu 24.04 image.

Base image update:

* Updated the `FROM` line in `Dockerfile` to use a newer Ubuntu 24.04 image digest, ensuring the build uses the most recent upstream image.