### PR TITLE
Add ignore for unfixable CVE alert

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -1,3 +1,12 @@
 ---
 # Grype configuration file for container vulnerability scanning
 # https://oss.anchore.com/docs/reference/grype/configuration/
+
+# Ignore rules for known vulnerabilities that cannot be easily fixed
+ignore:
+  - vulnerability: CVE-2026-15308
+    reason: |
+      This vulnerability is in Python 3.14.6 bundled within AWS CLI v2.35.17.
+      AWS CLI bundles its own Python runtime and cannot be easily upgraded without
+      rebuilding AWS CLI itself. AWS CLI v2.35.17 is the latest available version.
+      This is an acceptable risk for an Airflow runtime image.


### PR DESCRIPTION
This pull request updates the `.grype.yml` configuration file to add an ignore rule for a known vulnerability in the AWS CLI's bundled Python runtime. This helps prevent unnecessary alerts for a vulnerability that cannot be easily fixed in the current environment.

Security and vulnerability management:

* Added an ignore rule for CVE-2026-15308 in `.grype.yml`, documenting that the vulnerability exists in Python 3.14.6 bundled with AWS CLI v2.35.17, which cannot be upgraded without rebuilding AWS CLI. The change includes a justification for accepting this risk in the Airflow runtime image.