### PR TITLE
Add CVE to grype.yml as no fix available

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -1,0 +1,15 @@
+ignore:
+  - vulnerability: CVE-2026-11940
+    reason: >-
+      False positive / not currently remediable in this repository: AWS CLI v2
+      bundles Python 3.14.6 and upstream AWS CLI has not yet published a release
+      that upgrades the bundled runtime to a fixed version (>= 3.15.0b4).
+      Scope is limited to the embedded interpreter at
+      /usr/local/aws-cli/v2/*/dist/libpython3.14.so.1.0.
+  - vulnerability: CVE-2026-11972
+    reason: >-
+      False positive / not currently remediable in this repository: AWS CLI v2
+      bundles Python 3.14.6 and upstream AWS CLI has not yet published a release
+      that upgrades the bundled runtime to a fixed version (>= 3.15.0b4).
+      Scope is limited to the embedded interpreter at
+      /usr/local/aws-cli/v2/*/dist/libpython3.14.so.1.0.

--- a/.grype.yml
+++ b/.grype.yml
@@ -12,7 +12,7 @@ ignore:
       This is an acceptable risk for an Airflow runtime image.
   - vulnerability: CVE-2026-11940
     expires-at: "2026-08-11"
-    reason: >-
+    reason: &aws_cli_embedded_python_reason >-
       False positive / not currently remediable in this repository: AWS CLI v2
       bundles Python 3.14.6 and upstream AWS CLI has not yet published a release
       that upgrades the bundled runtime to a fixed version (>= 3.15.0b4).
@@ -20,9 +20,4 @@ ignore:
       /usr/local/aws-cli/v2/*/dist/libpython3.14.so.1.0.
   - vulnerability: CVE-2026-11972
     expires-at: "2026-08-11"
-    reason: >-
-      False positive / not currently remediable in this repository: AWS CLI v2
-      bundles Python 3.14.6 and upstream AWS CLI has not yet published a release
-      that upgrades the bundled runtime to a fixed version (>= 3.15.0b4).
-      Scope is limited to the embedded interpreter at
-      /usr/local/aws-cli/v2/*/dist/libpython3.14.so.1.0.
+    reason: *aws_cli_embedded_python_reason

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,5 +1,6 @@
 ignore:
   - vulnerability: CVE-2026-11940
+    expires-at: "2026-08-11"
     reason: >-
       False positive / not currently remediable in this repository: AWS CLI v2
       bundles Python 3.14.6 and upstream AWS CLI has not yet published a release
@@ -7,6 +8,7 @@ ignore:
       Scope is limited to the embedded interpreter at
       /usr/local/aws-cli/v2/*/dist/libpython3.14.so.1.0.
   - vulnerability: CVE-2026-11972
+    expires-at: "2026-08-11"
     reason: >-
       False positive / not currently remediable in this repository: AWS CLI v2
       bundles Python 3.14.6 and upstream AWS CLI has not yet published a release

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,4 +1,15 @@
+---
+# Grype configuration file for container vulnerability scanning
+# https://oss.anchore.com/docs/reference/grype/configuration/
+
+# Ignore rules for known vulnerabilities that cannot be easily fixed
 ignore:
+  - vulnerability: CVE-2026-15308
+    reason: |
+      This vulnerability is in Python 3.14.6 bundled within AWS CLI v2.35.17.
+      AWS CLI bundles its own Python runtime and cannot be easily upgraded without
+      rebuilding AWS CLI itself. AWS CLI v2.35.17 is the latest available version.
+      This is an acceptable risk for an Airflow runtime image.
   - vulnerability: CVE-2026-11940
     expires-at: "2026-08-11"
     reason: >-
@@ -15,15 +26,4 @@ ignore:
       that upgrades the bundled runtime to a fixed version (>= 3.15.0b4).
       Scope is limited to the embedded interpreter at
       /usr/local/aws-cli/v2/*/dist/libpython3.14.so.1.0.
----
-# Grype configuration file for container vulnerability scanning
-# https://oss.anchore.com/docs/reference/grype/configuration/
 
-# Ignore rules for known vulnerabilities that cannot be easily fixed
-ignore:
-  - vulnerability: CVE-2026-15308
-    reason: |
-      This vulnerability is in Python 3.14.6 bundled within AWS CLI v2.35.17.
-      AWS CLI bundles its own Python runtime and cannot be easily upgraded without
-      rebuilding AWS CLI itself. AWS CLI v2.35.17 is the latest available version.
-      This is an acceptable risk for an Airflow runtime image.

--- a/.grype.yml
+++ b/.grype.yml
@@ -26,4 +26,3 @@ ignore:
       that upgrades the bundled runtime to a fixed version (>= 3.15.0b4).
       Scope is limited to the embedded interpreter at
       /usr/local/aws-cli/v2/*/dist/libpython3.14.so.1.0.
-


### PR DESCRIPTION
This pull request updates the `.grype.yml` configuration to ignore two specific vulnerabilities related to the AWS CLI v2. These are marked as false positives or not currently remediable due to the upstream dependency on Python 3.14.6, which has not yet been updated by AWS CLI. Both ignores are set to expire on August 11, 2026.

Security configuration updates:

* Added ignores for vulnerabilities `CVE-2026-11940` and `CVE-2026-11972` in `.grype.yml`, with detailed justifications and expiration dates, due to their association with the embedded Python runtime in AWS CLI v2 and the lack of an upstream fix.